### PR TITLE
feat: feature strict encoding on monero types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base58-monero"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d079cdf47e1ca75554200bb2f30bff5a5af16964cac4a566b18de9a5d48db2b"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "bech32"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,6 +248,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
 name = "curve25519-dalek"
 version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,6 +383,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixed-hash"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
+dependencies = [
+ "byteorder",
+ "rand 0.8.5",
+ "rustc-hex",
+ "static_assertions",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,6 +476,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
 
 [[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -456,6 +492,18 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-literal"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
 name = "ident_case"
@@ -528,6 +576,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "monero"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be363920a304283a18c33a2e3312d46e209a7f6ccda1535f59768e03ede4f0fb"
+dependencies = [
+ "base58-monero",
+ "curve25519-dalek",
+ "fixed-hash",
+ "hex",
+ "hex-literal",
+ "sealed",
+ "thiserror",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -744,6 +808,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+
+[[package]]
 name = "rustc-serialize"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -772,6 +842,18 @@ name = "ryu"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+
+[[package]]
+name = "sealed"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b5e421024b5e5edfbaa8e60ecf90bda9dbffc602dbb230e6028763f85f0c68c"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "secp256k1"
@@ -894,6 +976,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strict_encoding"
 version = "0.8.0"
 dependencies = [
@@ -905,6 +993,7 @@ dependencies = [
  "grin_secp256k1zkp",
  "half",
  "miniscript",
+ "monero",
  "rand 0.7.3",
  "serde",
  "strict_encoding_derive",
@@ -1034,6 +1123,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1053,6 +1151,12 @@ name = "unicode-ident"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-width"

--- a/strict_encoding/Cargo.toml
+++ b/strict_encoding/Cargo.toml
@@ -29,6 +29,7 @@ grin_secp256k1zkp = { version = "0.7", optional = true }
 chrono = { version = "0.4", optional = true }
 half = { version = "1.8", optional = true }
 serde = { version = "1", optional = true }
+monero = { version = "0.17", optional = true }
 
 [dev-dependencies]
 rand = "0.7"
@@ -37,7 +38,7 @@ strict_encoding_test = { version = "0.8.0", path = "./test_helpers" }
 
 [features]
 default = ["chrono", "derive", "bitcoin"]
-all = ["float", "miniscript", "crypto", "chrono", "derive", "bitcoin", "serde"]
+all = ["float", "miniscript", "crypto", "chrono", "derive", "bitcoin", "serde", "monero"]
 crypto = ["ed25519-dalek", "grin_secp256k1zkp", "bitcoin"]
 derive = ["strict_encoding_derive"]
 float = ["amplify/apfloat", "half"]

--- a/strict_encoding/src/bitcoin.rs
+++ b/strict_encoding/src/bitcoin.rs
@@ -1225,9 +1225,9 @@ pub(crate) mod test {
 
         // test random and null outpoints
         let outpoint = OutPoint::new(txid, vout);
-        let _ = test_encoding_roundtrip(&outpoint, &OUTPOINT).unwrap();
+        test_encoding_roundtrip(&outpoint, &OUTPOINT).unwrap();
         let null = OutPoint::null();
-        let _ = test_encoding_roundtrip(&null, &OUTPOINT_NULL).unwrap();
+        test_encoding_roundtrip(&null, &OUTPOINT_NULL).unwrap();
     }
 
     #[test]

--- a/strict_encoding/src/lib.rs
+++ b/strict_encoding/src/lib.rs
@@ -78,6 +78,8 @@ mod collections;
 mod crypto;
 #[cfg(feature = "miniscript")]
 mod miniscript;
+#[cfg(feature = "monero")]
+mod monero;
 pub mod net;
 mod pointers;
 mod primitives;

--- a/strict_encoding/src/monero.rs
+++ b/strict_encoding/src/monero.rs
@@ -1,0 +1,258 @@
+// LNP/BP client-side-validation foundation libraries implementing LNPBP
+// specifications & standards (LNPBP-4, 7, 8, 9, 42, 81)
+//
+// Written in 2019-2022 by
+//     Dr. Maxim Orlovsky <orlovsky@pandoracore.com>
+//     h4sh3d <h4sh3d@protonmail.com>
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the Apache 2.0 License along with this
+// software. If not, see <https://opensource.org/licenses/Apache-2.0>.
+
+use std::io;
+
+use monero::{
+    blockdata::{
+        block::{Block, BlockHeader},
+        transaction::{
+            ExtraField, KeyImage, SubField, Transaction, TransactionPrefix,
+            TxIn, TxOut, TxOutTarget,
+        },
+    },
+    cryptonote::{
+        hash::{Hash, Hash8},
+        subaddress::Index,
+    },
+    util::{
+        address::{Address, PaymentId},
+        amount::{Amount, SignedAmount},
+        key::{KeyPair, PrivateKey, PublicKey, ViewPair},
+        ringct::{
+            BoroSig, Bulletproof, Clsag, CtKey, EcdhInfo, Key, Key64, MgSig,
+            MultisigKlrki, MultisigOut, RangeSig, RctSigBase, RctType,
+            Signature,
+        },
+    },
+    VarInt,
+};
+
+use crate::{strategies, Error, Strategy, StrictDecode, StrictEncode};
+
+impl Strategy for Transaction {
+    type Strategy = strategies::MoneroConsensus;
+}
+
+impl Strategy for TransactionPrefix {
+    type Strategy = strategies::MoneroConsensus;
+}
+
+impl Strategy for Block {
+    type Strategy = strategies::MoneroConsensus;
+}
+
+impl Strategy for BlockHeader {
+    type Strategy = strategies::MoneroConsensus;
+}
+
+impl Strategy for SubField {
+    type Strategy = strategies::MoneroConsensus;
+}
+
+impl Strategy for TxIn {
+    type Strategy = strategies::MoneroConsensus;
+}
+
+impl Strategy for ExtraField {
+    type Strategy = strategies::MoneroConsensus;
+}
+
+impl Strategy for KeyImage {
+    type Strategy = strategies::MoneroConsensus;
+}
+
+impl Strategy for TxOut {
+    type Strategy = strategies::MoneroConsensus;
+}
+
+impl Strategy for TxOutTarget {
+    type Strategy = strategies::MoneroConsensus;
+}
+
+impl Strategy for EcdhInfo {
+    type Strategy = strategies::MoneroConsensus;
+}
+
+impl Strategy for RctType {
+    type Strategy = strategies::MoneroConsensus;
+}
+
+impl Strategy for PublicKey {
+    type Strategy = strategies::MoneroConsensus;
+}
+
+impl Strategy for PrivateKey {
+    type Strategy = strategies::MoneroConsensus;
+}
+
+impl Strategy for Hash {
+    type Strategy = strategies::MoneroConsensus;
+}
+
+impl Strategy for Hash8 {
+    type Strategy = strategies::MoneroConsensus;
+}
+
+impl Strategy for Address {
+    type Strategy = strategies::MoneroConsensus;
+}
+
+impl Strategy for BoroSig {
+    type Strategy = strategies::MoneroConsensus;
+}
+
+impl Strategy for Bulletproof {
+    type Strategy = strategies::MoneroConsensus;
+}
+
+impl Strategy for Clsag {
+    type Strategy = strategies::MoneroConsensus;
+}
+
+impl Strategy for CtKey {
+    type Strategy = strategies::MoneroConsensus;
+}
+
+impl Strategy for Key64 {
+    type Strategy = strategies::MoneroConsensus;
+}
+
+impl Strategy for Key {
+    type Strategy = strategies::MoneroConsensus;
+}
+
+impl Strategy for MgSig {
+    type Strategy = strategies::MoneroConsensus;
+}
+
+impl Strategy for MultisigKlrki {
+    type Strategy = strategies::MoneroConsensus;
+}
+
+impl Strategy for MultisigOut {
+    type Strategy = strategies::MoneroConsensus;
+}
+
+impl Strategy for RangeSig {
+    type Strategy = strategies::MoneroConsensus;
+}
+
+impl Strategy for RctSigBase {
+    type Strategy = strategies::MoneroConsensus;
+}
+
+impl Strategy for Signature {
+    type Strategy = strategies::MoneroConsensus;
+}
+
+impl Strategy for VarInt {
+    type Strategy = strategies::MoneroConsensus;
+}
+
+impl StrictEncode for Amount {
+    #[inline]
+    fn strict_encode<E: io::Write>(&self, mut e: E) -> Result<usize, Error> {
+        self.as_pico().strict_encode(&mut e)
+    }
+}
+
+impl StrictDecode for Amount {
+    #[inline]
+    fn strict_decode<D: io::Read>(mut d: D) -> Result<Self, Error> {
+        Ok(Self::from_pico(u64::strict_decode(&mut d)?))
+    }
+}
+
+impl StrictEncode for SignedAmount {
+    #[inline]
+    fn strict_encode<E: io::Write>(&self, mut e: E) -> Result<usize, Error> {
+        self.as_pico().strict_encode(&mut e)
+    }
+}
+
+impl StrictDecode for SignedAmount {
+    #[inline]
+    fn strict_decode<D: io::Read>(mut d: D) -> Result<Self, Error> {
+        Ok(Self::from_pico(i64::strict_decode(&mut d)?))
+    }
+}
+
+impl StrictEncode for PaymentId {
+    #[inline]
+    fn strict_encode<E: io::Write>(&self, mut e: E) -> Result<usize, Error> {
+        Ok(e.write(&self.to_fixed_bytes())?)
+    }
+}
+
+impl StrictDecode for PaymentId {
+    #[inline]
+    fn strict_decode<D: io::Read>(mut d: D) -> Result<Self, Error> {
+        let mut bytes = [0u8; 8];
+        d.read_exact(&mut bytes)?;
+        Ok(Self::from(bytes))
+    }
+}
+
+impl StrictEncode for Index {
+    #[inline]
+    fn strict_encode<E: io::Write>(&self, mut e: E) -> Result<usize, Error> {
+        self.major.strict_encode(&mut e)?;
+        self.minor.strict_encode(e)
+    }
+}
+
+impl StrictDecode for Index {
+    #[inline]
+    fn strict_decode<D: io::Read>(mut d: D) -> Result<Self, Error> {
+        let major = u32::strict_decode(&mut d)?;
+        let minor = u32::strict_decode(d)?;
+        Ok(Self { major, minor })
+    }
+}
+
+impl StrictEncode for KeyPair {
+    #[inline]
+    fn strict_encode<E: io::Write>(&self, mut e: E) -> Result<usize, Error> {
+        self.view.strict_encode(&mut e)?;
+        self.spend.strict_encode(e)
+    }
+}
+
+impl StrictDecode for KeyPair {
+    #[inline]
+    fn strict_decode<D: io::Read>(mut d: D) -> Result<Self, Error> {
+        let view = PrivateKey::strict_decode(&mut d)?;
+        let spend = PrivateKey::strict_decode(d)?;
+        Ok(Self { view, spend })
+    }
+}
+
+impl StrictEncode for ViewPair {
+    #[inline]
+    fn strict_encode<E: io::Write>(&self, mut e: E) -> Result<usize, Error> {
+        self.view.strict_encode(&mut e)?;
+        self.spend.strict_encode(e)
+    }
+}
+
+impl StrictDecode for ViewPair {
+    #[inline]
+    fn strict_decode<D: io::Read>(mut d: D) -> Result<Self, Error> {
+        let view = PrivateKey::strict_decode(&mut d)?;
+        let spend = PublicKey::strict_decode(d)?;
+        Ok(Self { view, spend })
+    }
+}

--- a/strict_encoding/src/monero.rs
+++ b/strict_encoding/src/monero.rs
@@ -182,67 +182,56 @@ impl StrictDecode for SignedAmount {
 
 impl StrictEncode for PaymentId {
     #[inline]
-    fn strict_encode<E: io::Write>(&self, mut e: E) -> Result<usize, Error> {
-        Ok(e.write(&self.to_fixed_bytes())?)
+    fn strict_encode<E: io::Write>(&self, e: E) -> Result<usize, Error> {
+        self.to_fixed_bytes().strict_encode(e)
     }
 }
 
 impl StrictDecode for PaymentId {
     #[inline]
-    fn strict_decode<D: io::Read>(mut d: D) -> Result<Self, Error> {
-        let mut bytes = [0u8; 8];
-        d.read_exact(&mut bytes)?;
-        Ok(Self::from(bytes))
+    fn strict_decode<D: io::Read>(d: D) -> Result<Self, Error> {
+        <[u8; 8]>::strict_decode(d).map(Self::from)
     }
 }
 
 impl StrictEncode for Index {
     #[inline]
     fn strict_encode<E: io::Write>(&self, mut e: E) -> Result<usize, Error> {
-        self.major.strict_encode(&mut e)?;
-        self.minor.strict_encode(e)
+        Ok(strict_encode_list!(e; self.major, self.minor))
     }
 }
 
 impl StrictDecode for Index {
     #[inline]
     fn strict_decode<D: io::Read>(mut d: D) -> Result<Self, Error> {
-        let major = u32::strict_decode(&mut d)?;
-        let minor = u32::strict_decode(d)?;
-        Ok(Self { major, minor })
+        Ok(strict_decode_self!(d; major, minor; crate))
     }
 }
 
 impl StrictEncode for KeyPair {
     #[inline]
     fn strict_encode<E: io::Write>(&self, mut e: E) -> Result<usize, Error> {
-        self.view.strict_encode(&mut e)?;
-        self.spend.strict_encode(e)
+        Ok(strict_encode_list!(e; self.view, self.spend))
     }
 }
 
 impl StrictDecode for KeyPair {
     #[inline]
     fn strict_decode<D: io::Read>(mut d: D) -> Result<Self, Error> {
-        let view = PrivateKey::strict_decode(&mut d)?;
-        let spend = PrivateKey::strict_decode(d)?;
-        Ok(Self { view, spend })
+        Ok(strict_decode_self!(d; view, spend; crate))
     }
 }
 
 impl StrictEncode for ViewPair {
     #[inline]
     fn strict_encode<E: io::Write>(&self, mut e: E) -> Result<usize, Error> {
-        self.view.strict_encode(&mut e)?;
-        self.spend.strict_encode(e)
+        Ok(strict_encode_list!(e; self.view, self.spend))
     }
 }
 
 impl StrictDecode for ViewPair {
     #[inline]
     fn strict_decode<D: io::Read>(mut d: D) -> Result<Self, Error> {
-        let view = PrivateKey::strict_decode(&mut d)?;
-        let spend = PublicKey::strict_decode(d)?;
-        Ok(Self { view, spend })
+        Ok(strict_decode_self!(d; view, spend; crate))
     }
 }

--- a/strict_encoding/src/monero.rs
+++ b/strict_encoding/src/monero.rs
@@ -15,30 +15,21 @@
 
 use std::io;
 
-use monero::{
-    blockdata::{
-        block::{Block, BlockHeader},
-        transaction::{
-            ExtraField, KeyImage, SubField, Transaction, TransactionPrefix,
-            TxIn, TxOut, TxOutTarget,
-        },
-    },
-    cryptonote::{
-        hash::{Hash, Hash8},
-        subaddress::Index,
-    },
-    util::{
-        address::{Address, PaymentId},
-        amount::{Amount, SignedAmount},
-        key::{KeyPair, PrivateKey, PublicKey, ViewPair},
-        ringct::{
-            BoroSig, Bulletproof, Clsag, CtKey, EcdhInfo, Key, Key64, MgSig,
-            MultisigKlrki, MultisigOut, RangeSig, RctSigBase, RctType,
-            Signature,
-        },
-    },
-    VarInt,
+use monero::blockdata::block::{Block, BlockHeader};
+use monero::blockdata::transaction::{
+    ExtraField, KeyImage, SubField, Transaction, TransactionPrefix, TxIn,
+    TxOut, TxOutTarget,
 };
+use monero::cryptonote::hash::{Hash, Hash8};
+use monero::cryptonote::subaddress::Index;
+use monero::util::address::{Address, PaymentId};
+use monero::util::amount::{Amount, SignedAmount};
+use monero::util::key::{KeyPair, PrivateKey, PublicKey, ViewPair};
+use monero::util::ringct::{
+    BoroSig, Bulletproof, Clsag, CtKey, EcdhInfo, Key, Key64, MgSig,
+    MultisigKlrki, MultisigOut, RangeSig, RctSigBase, RctType, Signature,
+};
+use monero::VarInt;
 
 use crate::{strategies, Error, Strategy, StrictDecode, StrictEncode};
 

--- a/strict_encoding/src/monero.rs
+++ b/strict_encoding/src/monero.rs
@@ -1,8 +1,7 @@
 // LNP/BP client-side-validation foundation libraries implementing LNPBP
 // specifications & standards (LNPBP-4, 7, 8, 9, 42, 81)
 //
-// Written in 2019-2022 by
-//     Dr. Maxim Orlovsky <orlovsky@pandoracore.com>
+// Written in 2022 by
 //     h4sh3d <h4sh3d@protonmail.com>
 //
 // To the extent possible under law, the author(s) have dedicated all

--- a/strict_encoding/src/strategies.rs
+++ b/strict_encoding/src/strategies.rs
@@ -53,6 +53,7 @@ pub trait Strategy {
     /// - [`BitcoinConsensus`]
     /// - [`Wrapped`]
     /// - [`UsingUniformAddr`]
+    /// - [`MoneroConsensus`]
     type Strategy;
 }
 


### PR DESCRIPTION
Add a feature `monero`, disable by default, implementing Strict Encode and Strict Decode on main Monero types from monero-rs/monero-rs.