### PR TITLE
fix merkle proof conversion

### DIFF
--- a/commit_verify/src/lnpbp4.rs
+++ b/commit_verify/src/lnpbp4.rs
@@ -843,8 +843,9 @@ impl MerkleBlock {
         for node in &self.cross_section {
             match node {
                 TreeNode::ConcealedNode { depth, hash } => {
+                    let inserted = map.insert(*depth, *hash).is_none();
                     debug_assert!(
-                        map.insert(*depth, *hash).is_none(),
+                        inserted,
                         "MerkleBlock conceal procedure is broken"
                     );
                 }


### PR DESCRIPTION
**Description**
The `rgb-node` produces an incorrect **merkle proof anchor** when compiled in release mode.

This problem occurs because the conversion of the _merkle block_ into a _merkle proof_ was inside the **debug_assert** method. 


Closes: 
- https://github.com/LNP-BP/nodes/issues/16
- https://github.com/RGB-WG/rgb-core/issues/113

Related:
- https://github.com/RGB-WG/rgb-node/issues/197
