### PR TITLE
Temp change of unreachable for known bug

### DIFF
--- a/commit_verify/src/lnpbp4.rs
+++ b/commit_verify/src/lnpbp4.rs
@@ -823,7 +823,7 @@ impl MerkleBlock {
                 }));
                 last_b = b.next();
             } else {
-                unreachable!("broken merkle block merge-reveal algorithm")
+                return Err(UnrelatedProof)
             }
         }
 


### PR DESCRIPTION
This PR refers to what has been discussed here https://github.com/RGB-WG/rgb-node/issues/208#issuecomment-1348468408

I know that `UnrelatedProof` is not the correct error in this case, but trying to change it to something else causes bp-dbc to stop compiling and I don't think we should change everything for a very temporary change. @dr-orlovsky please let me know if I'm missing a simple way to introduce a proper error
