### PR TITLE
Fix for merging LNPBP4 merkle blocks

### DIFF
--- a/commit_verify/src/lnpbp4.rs
+++ b/commit_verify/src/lnpbp4.rs
@@ -934,6 +934,7 @@ impl MerkleProof {
 
 #[cfg(test)]
 mod test {
+    use std::str::FromStr;
     use super::*;
     use crate::TryCommitVerify;
 
@@ -1170,5 +1171,58 @@ mod test {
             .conceal_except(src.messages.into_keys().collect::<Vec<_>>())
             .unwrap();
         assert_eq!(orig_block, new_block);
+    }
+
+    #[test]
+    fn test_merge_blocks() {
+        let mut block1 = MerkleBlock {
+            depth: 3,
+            cross_section: vec![
+                TreeNode::ConcealedNode {
+                    depth: 3,
+                    hash: MerkleNode::from_str("03e43c730e76e654a40fdc0b62940bb7382ed95d4e8124ba687b4ec470cd1f01").unwrap()
+                },
+                TreeNode::CommitmentLeaf {
+                    protocol_id: ProtocolId::from_str("391cfae9f7b23562826b3260831e92698c7ec43c49e7afeed8e83a1bd75bbce9").unwrap(),
+                    message: Message::from_str("72c7278c8337a0480aa343dae2e6e6e1aee6c7b3df7d88f150a21c82f2b373ac").unwrap()
+                },
+                TreeNode::ConcealedNode {
+                    depth: 2,
+                    hash: MerkleNode::from_str("d42b5b6f1d6cc564fea2258e5147f4dd07735fac5aafa4a8394feb75ed8e366d").unwrap()
+                },
+                TreeNode::ConcealedNode {
+                    depth: 1,
+                    hash: MerkleNode::from_str("5009030a186d268e698e184cf9e32607951ab81c6e3b42ecaf6ccf73a5ca0f2e").unwrap()
+                },
+            ],
+            entropy: None,
+        };
+
+        let block2 = MerkleBlock {
+            depth: 3,
+            cross_section: vec![
+                TreeNode::CommitmentLeaf {
+                    protocol_id: ProtocolId::from_str("f0f2fc11fa38f3fd6132f46d8044612fc73e26b769025edabbe1290af9851897").unwrap(),
+                    message: Message::from_str("c0abbb938d4da7ce3a25e704b5b41dbacc762afe45a536e7d0a962fb1b34413e").unwrap()
+                },
+                TreeNode::ConcealedNode {
+                    depth: 3,
+                    hash: MerkleNode::from_str("8fff224a68c261d62ab33d802182ff09d6332e9079fce71936ea414ed45ee782").unwrap()
+                },
+                TreeNode::ConcealedNode {
+                    depth: 2,
+                    hash: MerkleNode::from_str("d42b5b6f1d6cc564fea2258e5147f4dd07735fac5aafa4a8394feb75ed8e366d").unwrap()
+                },
+                TreeNode::ConcealedNode {
+                    depth: 1,
+                    hash: MerkleNode::from_str("5009030a186d268e698e184cf9e32607951ab81c6e3b42ecaf6ccf73a5ca0f2e").unwrap()
+                },
+            ],
+            entropy: None,
+        };
+
+        block1.merge_reveal(block2).unwrap();
+
+        println!("{:?}", block1);
     }
 }

--- a/commit_verify/src/lnpbp4.rs
+++ b/commit_verify/src/lnpbp4.rs
@@ -794,7 +794,7 @@ impl MerkleBlock {
         let mut last_a = a.next();
         let mut last_b = b.next();
         while let (Some(n1), Some(n2)) = (last_a, last_b) {
-            if n1 == n2 {
+            if n1.depth_or(self.depth) == n2.depth_or(self.depth) {
                 cross_section.push(n1);
                 last_a = a.next();
                 last_b = b.next();

--- a/commit_verify/src/lnpbp4.rs
+++ b/commit_verify/src/lnpbp4.rs
@@ -1226,8 +1226,31 @@ mod test {
             entropy: None,
         };
 
+        let expected = MerkleBlock {
+            depth: 3,
+            cross_section: vec![
+                TreeNode::CommitmentLeaf {
+                    protocol_id: ProtocolId::from_str("f0f2fc11fa38f3fd6132f46d8044612fc73e26b769025edabbe1290af9851897").unwrap(),
+                    message: Message::from_str("c0abbb938d4da7ce3a25e704b5b41dbacc762afe45a536e7d0a962fb1b34413e").unwrap()
+                },
+                TreeNode::CommitmentLeaf {
+                    protocol_id: ProtocolId::from_str("391cfae9f7b23562826b3260831e92698c7ec43c49e7afeed8e83a1bd75bbce9").unwrap(),
+                    message: Message::from_str("72c7278c8337a0480aa343dae2e6e6e1aee6c7b3df7d88f150a21c82f2b373ac").unwrap()
+                },
+                TreeNode::ConcealedNode {
+                    depth: 2,
+                    hash: MerkleNode::from_str("d42b5b6f1d6cc564fea2258e5147f4dd07735fac5aafa4a8394feb75ed8e366d").unwrap()
+                },
+                TreeNode::ConcealedNode {
+                    depth: 1,
+                    hash: MerkleNode::from_str("5009030a186d268e698e184cf9e32607951ab81c6e3b42ecaf6ccf73a5ca0f2e").unwrap()
+                },
+            ],
+            entropy: None,
+        };
+
         block1.merge_reveal(block2).unwrap();
 
-        println!("{:?}", block1);
+        assert_eq!(block1, expected);
     }
 }

--- a/strict_encoding/derive_helpers/src/decode.rs
+++ b/strict_encoding/derive_helpers/src/decode.rs
@@ -228,7 +228,7 @@ fn decode_enum_impl(
         let ident = &variant.ident;
         let value = match (encoding.value, encoding.by_order) {
             (Some(val), _) => val.to_token_stream(),
-            (None, true) => Index::from(order as usize).to_token_stream(),
+            (None, true) => Index::from(order).to_token_stream(),
             (None, false) => quote! { Self::#ident as #repr },
         };
 

--- a/strict_encoding/derive_helpers/src/encode.rs
+++ b/strict_encoding/derive_helpers/src/encode.rs
@@ -251,7 +251,7 @@ fn encode_enum_impl(
         let ident = &variant.ident;
         let value = match (encoding.value, encoding.by_order) {
             (Some(val), _) => val.to_token_stream(),
-            (None, true) => Index::from(order as usize).to_token_stream(),
+            (None, true) => Index::from(order).to_token_stream(),
             (None, false) => quote! { Self::#ident },
         };
 

--- a/strict_encoding/src/collections.rs
+++ b/strict_encoding/src/collections.rs
@@ -196,7 +196,7 @@ where
     T: StrictEncode,
 {
     fn strict_encode<E: io::Write>(&self, mut e: E) -> Result<usize, Error> {
-        let len = self.len() as usize;
+        let len = self.len();
         // We handle oversize problems at the level of `usize` value
         // serializaton
         let mut encoded = len.strict_encode(&mut e)?;
@@ -504,7 +504,7 @@ where
 {
     fn strict_decode<D: io::Read>(mut d: D) -> Result<Self, Error> {
         let len = usize::strict_decode(&mut d)?;
-        let mut data = Vec::<T>::with_capacity(len as usize);
+        let mut data = Vec::<T>::with_capacity(len);
         for _ in 0..len {
             data.push(T::strict_decode(&mut d)?);
         }
@@ -522,7 +522,7 @@ where
     T: StrictEncode + Eq + Ord + Hash + Debug,
 {
     fn strict_encode<E: io::Write>(&self, mut e: E) -> Result<usize, Error> {
-        let len = self.len() as usize;
+        let len = self.len();
         let mut encoded = len.strict_encode(&mut e)?;
         let mut vec: Vec<&T> = self.iter().collect();
         vec.sort();
@@ -543,7 +543,7 @@ where
 {
     fn strict_decode<D: io::Read>(mut d: D) -> Result<Self, Error> {
         let len = usize::strict_decode(&mut d)?;
-        let mut data = HashSet::<T>::with_capacity(len as usize);
+        let mut data = HashSet::<T>::with_capacity(len);
         for _ in 0..len {
             let val = T::strict_decode(&mut d)?;
             if data.contains(&val) {
@@ -566,7 +566,7 @@ where
     T: StrictEncode + Eq + Ord + Debug,
 {
     fn strict_encode<E: io::Write>(&self, mut e: E) -> Result<usize, Error> {
-        let len = self.len() as usize;
+        let len = self.len();
         let mut encoded = len.strict_encode(&mut e)?;
         let mut vec: Vec<&T> = self.iter().collect();
         vec.sort();
@@ -669,7 +669,7 @@ where
     V: StrictEncode + Clone,
 {
     fn strict_encode<E: io::Write>(&self, mut e: E) -> Result<usize, Error> {
-        let len = self.len() as usize;
+        let len = self.len();
         let encoded = len.strict_encode(&mut e)?;
 
         self.iter().try_fold(encoded, |mut acc, (key, val)| {

--- a/strict_encoding/src/miniscript.rs
+++ b/strict_encoding/src/miniscript.rs
@@ -193,8 +193,8 @@ where
                 let vec1 = Vec::<u8>::strict_decode(&mut d)?;
                 let vec2 = Vec::<u8>::strict_decode(&mut d)?;
                 Ok(TapTree::Tree(
-                    Arc::new(TapTree::strict_deserialize(&vec1)?),
-                    Arc::new(TapTree::strict_deserialize(&vec2)?),
+                    Arc::new(TapTree::strict_deserialize(vec1)?),
+                    Arc::new(TapTree::strict_deserialize(vec2)?),
                 ))
             }
             wrong => Err(Error::EnumValueNotKnown("TapTree", wrong as usize)),

--- a/strict_encoding/src/pointers.rs
+++ b/strict_encoding/src/pointers.rs
@@ -160,7 +160,7 @@ pub mod test {
     fn test_encode_decode() {
         gen_strings().into_iter().for_each(|s| {
             let r = strict_serialize(&s).unwrap();
-            let p: String = strict_deserialize(&r).unwrap();
+            let p: String = strict_deserialize(r).unwrap();
             assert_eq!(s, p);
         })
     }
@@ -171,7 +171,7 @@ pub mod test {
         gen_strings().into_iter().for_each(|s| {
             let mut r = strict_serialize(&s).unwrap();
             r.extend_from_slice("data".as_ref());
-            let _: String = strict_deserialize(&r).unwrap();
+            let _: String = strict_deserialize(r).unwrap();
         })
     }
 


### PR DESCRIPTION
The  problem was caused by a very simple oversight: 387af22ccec5fa2cd1142d8d31a84c8a5259ee30

It took me drawing a lot of charts to finally see the obvious mistake.

As far as I can see, this fix is not consensus-breaking, so after getting ACKs on this PR to master, I will backport it into `v0.8` and `v0.9` as well and will release `v0.8.3` version.

Additionally to the fix I made a test in 75fdf50c86a97c456e109de16845a73d98782305 which matches the merkle blocks which fails to merge from the original bug report https://github.com/RGB-WG/rgb-node/issues/208#issue-1389588781 This test fails before the fix is applied - and after the fix it passes successfully.

Next, I improved code style of merkle block merge in 1e11bd0e183134f2c80728e4e21feb545ba91b85 to ensure that the code is correct and problems like this can't be easily introduced in a future.