### PR TITLE
Require result of verify functions to be used

### DIFF
--- a/commit_verify/src/commit.rs
+++ b/commit_verify/src/commit.rs
@@ -43,6 +43,8 @@ where Self: Eq + Sized
     /// Verifies commitment against the message; default implementation just
     /// repeats the commitment to the message and check it against the `self`.
     #[inline]
+    #[must_use = "the boolean inside Ok(_) must be used since it carries the result of the \
+                  validation"]
     fn verify(&self, msg: &Msg) -> bool { Self::commit(msg) == *self }
 }
 
@@ -63,6 +65,8 @@ where Self: Eq + Sized
     /// just repeats the commitment to the message and check it against the
     /// `self`.
     #[inline]
+    #[must_use = "the boolean inside Ok(_) must be used since it carries the result of the \
+                  validation"]
     fn try_verify(&self, msg: &Msg) -> Result<bool, Self::Error> {
         Ok(Self::try_commit(msg)? == *self)
     }

--- a/commit_verify/src/convolve.rs
+++ b/commit_verify/src/convolve.rs
@@ -65,6 +65,8 @@ where
     /// However if the proofs are provided by some sort of user/network input
     /// from an untrusted party, a proper form would be
     /// `if commitment.verify(...).unwrap_or(false) { .. }`.
+    #[must_use = "the boolean inside Ok(_) must be used since it carries the result of the \
+                  validation"]
     fn verify(
         &self,
         msg: &Msg,

--- a/commit_verify/src/embed.rs
+++ b/commit_verify/src/embed.rs
@@ -148,6 +148,8 @@ where
     /// from an untrusted party, a proper form would be
     /// `if commitment.verify(...).unwrap_or(false) { .. }`.
     #[inline]
+    #[must_use = "the boolean inside Ok(_) must be used since it carries the result of the \
+                  validation"]
     fn verify(&self, msg: &Msg, proof: &Self::Proof) -> Result<bool, Self::VerifyError>
     where
         Self: VerifyEq,


### PR DESCRIPTION
Will switch to just `Result<(), VerifyError>` in v0.11