### PR TITLE
Fix verify functions' return type to be bool

### DIFF
--- a/commit_verify/src/commit.rs
+++ b/commit_verify/src/commit.rs
@@ -43,6 +43,7 @@ where Self: Eq + Sized
     /// Verifies commitment against the message; default implementation just
     /// repeats the commitment to the message and check it against the `self`.
     #[inline]
+    #[must_use = "the boolean carries the result of the verification"]
     fn verify(&self, msg: &Msg) -> bool { Self::commit(msg) == *self }
 }
 
@@ -59,12 +60,15 @@ where Self: Eq + Sized
     /// Tries to create commitment to a byte representation of a given message
     fn try_commit(msg: &Msg) -> Result<Self, Self::Error>;
 
-    /// Tries to verify commitment against the message; default implementation
+    /// Verifies commitment against the message; default implementation
     /// just repeats the commitment to the message and check it against the
     /// `self`.
     #[inline]
-    fn try_verify(&self, msg: &Msg) -> Result<bool, Self::Error> {
-        Ok(Self::try_commit(msg)? == *self)
+    #[must_use = "the boolean carries the result of the verification"]
+    fn verify(&self, msg: &Msg) -> bool {
+        Self::try_commit(msg)
+            .map(|other| other == *self)
+            .unwrap_or(false)
     }
 }
 

--- a/commit_verify/src/embed.rs
+++ b/commit_verify/src/embed.rs
@@ -197,18 +197,18 @@ pub(crate) mod test_helpers {
                 });
 
                 // Testing verification
-                assert!(commitment.clone().verify(msg, &proof).unwrap());
+                assert!(commitment.clone().verify(msg, &proof));
 
                 messages.iter().for_each(|m| {
                     // Testing that commitment verification succeeds only
                     // for the original message and fails for the rest
-                    assert_eq!(commitment.clone().verify(m, &proof).unwrap(), m == msg);
+                    assert_eq!(commitment.clone().verify(m, &proof), m == msg);
                 });
 
                 acc.iter().for_each(|cmt| {
                     // Testing that verification against other commitments
                     // returns `false`
-                    assert!(!cmt.clone().verify(msg, &proof).unwrap());
+                    assert!(!cmt.clone().verify(msg, &proof));
                 });
 
                 // Detecting collision: each message should produce a unique
@@ -243,18 +243,18 @@ pub(crate) mod test_helpers {
                 });
 
                 // Testing verification
-                assert!(SUPPLEMENT.verify(msg, &commitment).unwrap());
+                assert!(SUPPLEMENT.verify(msg, &commitment));
 
                 messages.iter().for_each(|m| {
                     // Testing that commitment verification succeeds only
                     // for the original message and fails for the rest
-                    assert_eq!(SUPPLEMENT.verify(m, &commitment).unwrap(), m == msg);
+                    assert_eq!(SUPPLEMENT.verify(m, &commitment), m == msg);
                 });
 
                 acc.iter().for_each(|commitment| {
                     // Testing that verification against other commitments
                     // returns `false`
-                    assert!(!SUPPLEMENT.verify(msg, commitment).unwrap());
+                    assert!(!SUPPLEMENT.verify(msg, commitment));
                 });
 
                 // Detecting collision: each message should produce a unique
@@ -293,8 +293,8 @@ mod test {
     impl<T> EmbedCommitProof<T, DummyVec, TestProtocol> for DummyProof
     where T: AsRef<[u8]> + Clone + CommitEncode
     {
-        fn restore_original_container(&self, _: &DummyVec) -> Result<DummyVec, Error> {
-            Ok(DummyVec(self.0.clone()))
+        fn restore_original_container(&self, _: &DummyVec) -> Option<DummyVec> {
+            Some(DummyVec(self.0.clone()))
         }
     }
 
@@ -303,7 +303,6 @@ mod test {
     {
         type Proof = DummyProof;
         type CommitError = Error;
-        type VerifyError = Error;
 
         fn embed_commit(&mut self, msg: &T) -> Result<Self::Proof, Self::CommitError> {
             let proof = self.0.clone();


### PR DESCRIPTION
Targeting v0.11, since it is a breaking API change