### PR TITLE
Commitment layouts and vesper description

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,6 +232,7 @@ dependencies = [
  "sha2",
  "strict_encoding",
  "strict_types",
+ "vesper-lang",
 ]
 
 [[package]]

--- a/commit_verify/Cargo.toml
+++ b/commit_verify/Cargo.toml
@@ -25,6 +25,7 @@ required-features = ["stl"]
 amplify = { workspace = true, features = ["hex", "apfloat"] }
 strict_encoding = { workspace = true }
 strict_types = { workspace = true }
+vesper-lang = "0.1.0"
 commit_encoding_derive = { version = "0.11.0-beta.3", path = "derive" }
 sha2 = "0.10.8"
 ripemd = "0.1.3"

--- a/commit_verify/derive/src/derive.rs
+++ b/commit_verify/derive/src/derive.rs
@@ -33,19 +33,19 @@ impl CommitDerive {
 
         let inner = match self.conf.strategy {
             StrategyAttr::Strict => quote! {
-                engine.commit_to(self);
+                engine.commit_to_serialized(self);
             },
             StrategyAttr::ConcealStrict => quote! {
                 use #trait_crate::Conceal;
-                engine.commit_to(&self.conceal());
+                engine.commit_to_concealed(&self.conceal());
             },
             StrategyAttr::Transparent => quote! {
                 use amplify::Wrapper;
-                engine.commit_to(self.as_inner());
+                engine.commit_to_serialized(self.as_inner());
             },
             StrategyAttr::Merklize => quote! {
                 use amplify::Wrapper;
-                engine.commit_to(self.as_inner().merklize());
+                engine.commit_to_merkle(self.as_inner().merklize());
             },
         };
 

--- a/commit_verify/src/id.rs
+++ b/commit_verify/src/id.rs
@@ -99,6 +99,15 @@ impl CommitEngine {
         self.inner_commit_to::<_, COMMIT_MAX_LEN>(&value);
     }
 
+    pub fn commit_to_option<T: StrictEncode + StrictDumb>(&mut self, value: &Option<T>) {
+        let fqn = commitment_fqn::<T>();
+        self.layout
+            .push(CommitStep::Serialized(fqn))
+            .expect("too many fields for commitment");
+
+        self.inner_commit_to::<_, COMMIT_MAX_LEN>(&value);
+    }
+
     pub fn commit_to_hash<T: CommitEncode<CommitmentId = StrictHash> + StrictType>(
         &mut self,
         value: T,

--- a/commit_verify/src/lib.rs
+++ b/commit_verify/src/lib.rs
@@ -62,7 +62,9 @@ pub use conceal::Conceal;
 pub use convolve::{ConvolveCommit, ConvolveCommitProof, ConvolveVerifyError};
 pub use digest::{Digest, DigestExt, Ripemd160, Sha256};
 pub use embed::{EmbedCommitProof, EmbedCommitVerify, EmbedVerifyError, VerifyEq};
-pub use id::{CommitEncode, CommitEngine, CommitId, CommitmentId, CommitmentLayout, StrictHash};
+pub use id::{
+    CommitEncode, CommitEngine, CommitId, CommitStep, CommitmentId, CommitmentLayout, StrictHash,
+};
 pub use merkle::{MerkleBuoy, MerkleHash, MerkleLeaves, MerkleNode, NodeBranching};
 
 pub const LIB_NAME_COMMIT_VERIFY: &str = "CommitVerify";

--- a/commit_verify/src/lib.rs
+++ b/commit_verify/src/lib.rs
@@ -56,6 +56,7 @@ pub mod stl;
 pub mod merkle;
 pub mod mpc;
 mod digest;
+pub mod vesper;
 
 pub use commit::{CommitVerify, TryCommitVerify, VerifyError};
 pub use conceal::Conceal;
@@ -63,7 +64,8 @@ pub use convolve::{ConvolveCommit, ConvolveCommitProof, ConvolveVerifyError};
 pub use digest::{Digest, DigestExt, Ripemd160, Sha256};
 pub use embed::{EmbedCommitProof, EmbedCommitVerify, EmbedVerifyError, VerifyEq};
 pub use id::{
-    CommitEncode, CommitEngine, CommitId, CommitStep, CommitmentId, CommitmentLayout, StrictHash,
+    CommitColType, CommitEncode, CommitEngine, CommitId, CommitStep, CommitmentId,
+    CommitmentLayout, StrictHash,
 };
 pub use merkle::{MerkleBuoy, MerkleHash, MerkleLeaves, MerkleNode, NodeBranching};
 

--- a/commit_verify/src/lib.rs
+++ b/commit_verify/src/lib.rs
@@ -64,7 +64,7 @@ pub use convolve::{ConvolveCommit, ConvolveCommitProof, ConvolveVerifyError};
 pub use digest::{Digest, DigestExt, Ripemd160, Sha256};
 pub use embed::{EmbedCommitProof, EmbedCommitVerify, EmbedVerifyError, VerifyEq};
 pub use id::{
-    CommitColType, CommitEncode, CommitEngine, CommitId, CommitStep, CommitmentId,
+    CommitColType, CommitEncode, CommitEngine, CommitId, CommitLayout, CommitStep, CommitmentId,
     CommitmentLayout, StrictHash,
 };
 pub use merkle::{MerkleBuoy, MerkleHash, MerkleLeaves, MerkleNode, NodeBranching};

--- a/commit_verify/src/mpc/tree.rs
+++ b/commit_verify/src/mpc/tree.rs
@@ -19,7 +19,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use amplify::confinement::{MediumOrdMap, SmallVec};
+use amplify::confinement::{LargeVec, MediumOrdMap};
 use amplify::num::{u256, u5};
 use amplify::Wrapper;
 
@@ -68,7 +68,7 @@ impl MerkleTree {
                 .map(|(protocol, msg)| Leaf::inhabited(*protocol, *msg))
                 .unwrap_or_else(|| Leaf::entropy(self.entropy, pos))
         });
-        let leaves = SmallVec::try_from_iter(iter).expect("u16-bound size");
+        let leaves = LargeVec::try_from_iter(iter).expect("tree width has u32-bound size");
         MerkleHash::merklize(&leaves)
     }
 }
@@ -281,18 +281,35 @@ mod test {
 
     #[test]
     fn tree_huge() {
+        // Tree with 8192 protocol-messages: depth 23, cofactor 103. Serialized length
+        // 1081361 bytes. Takes 71589 msecs to generate
+        // Root is 58755c63bbcb1a648982956c90a471a3fc79b12ae97867828e2f0ce8c9f7e7db.
+        // Takes 560735 msecs to compute
+
+        use std::time::Instant;
+
         let count = 1_048_576 / 128;
         let msgs = make_random_messages(count);
+
+        let start = Instant::now();
         let tree = make_random_tree(&msgs);
+        let elapsed_gen = start.elapsed();
+
         let mut counter = StreamWriter::counter::<{ usize::MAX }>();
         tree.strict_write(&mut counter).unwrap();
         eprintln!(
-            "Tree with {} protocol-messages: depth {}, cofactor {}. Serialized length {} bytes",
-            count,
+            "Tree with {count} protocol-messages: depth {}, cofactor {}. Serialized length {} \
+             bytes. Takes {} msecs to generate",
             tree.depth,
             tree.cofactor,
-            counter.unconfine().count
+            counter.unconfine().count,
+            elapsed_gen.as_millis(),
         );
+
+        let start = Instant::now();
+        let root = tree.root();
+        let elapsed_root = start.elapsed();
+        eprintln!("Root is {root}. Takes {} msecs to compute", elapsed_root.as_millis(),);
     }
 
     #[test]

--- a/commit_verify/src/vesper.rs
+++ b/commit_verify/src/vesper.rs
@@ -1,0 +1,185 @@
+// Client-side-validation foundation libraries.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Written in 2024 by
+//     Dr. Maxim Orlovsky <orlovsky@lnp-bp.org>
+//
+// Copyright (C) 2024 LNP/BP Standards Association. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use amplify::confinement::{Confined, SmallVec, TinyVec};
+use strict_encoding::Ident;
+use strict_types::layout::vesper::LenRange;
+use strict_types::typesys::TypeFqn;
+use vesper::{AttrVal, Attribute, Expression, Predicate, TExpr};
+
+use crate::{CommitColType, CommitStep, CommitmentLayout};
+
+pub type VesperCommit = TExpr<Pred>;
+
+#[derive(Clone, Eq, PartialEq, Hash, Debug, Display)]
+#[display(lowercase)]
+pub enum Pred {
+    Commitment,
+    Serialize,
+    Hash,
+    Merklize,
+    Conceal,
+    List,
+    Set,
+    Element,
+    Map,
+    #[display("mapKey")]
+    MapKey,
+    #[display("mapValue")]
+    MapValue,
+}
+
+impl Predicate for Pred {
+    type Attr = Attr;
+}
+
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
+pub enum Attr {
+    Tagged(&'static str),
+    Concealed(TypeFqn),
+    LenRange(LenRange),
+}
+#[derive(Clone, Eq, PartialEq, Hash, Debug, Display)]
+#[display(inner)]
+pub enum AttrExpr {
+    Tag(&'static str),
+    LenRange(LenRange),
+}
+
+impl Expression for AttrExpr {}
+
+impl Attribute for Attr {
+    type Expression = AttrExpr;
+
+    fn name(&self) -> Option<Ident> {
+        match self {
+            Attr::Tagged(_) => Some(tn!("tagged")),
+            Attr::Concealed(_) => Some(tn!("concealed")),
+            Attr::LenRange(_) => Some(tn!("len")),
+        }
+    }
+
+    fn value(&self) -> AttrVal<Self::Expression> {
+        match self {
+            Attr::Tagged(tag) => AttrVal::Expr(AttrExpr::Tag(tag)),
+            Attr::Concealed(fqn) => AttrVal::Ident(fqn.name.to_ident()),
+            Attr::LenRange(range) => AttrVal::Expr(AttrExpr::LenRange(range.clone())),
+        }
+    }
+}
+
+impl CommitStep {
+    fn subject(&self) -> Ident {
+        match self {
+            CommitStep::Serialized(fqn) => fqn,
+            CommitStep::Collection(_, _, fqn) => fqn,
+            CommitStep::Hashed(fqn) => fqn,
+            CommitStep::Merklized(fqn) => fqn,
+            CommitStep::Concealed(fqn) => fqn,
+        }
+        .name
+        .to_ident()
+    }
+
+    fn predicate(&self) -> Pred {
+        match self {
+            CommitStep::Serialized(_) => Pred::Serialize,
+            CommitStep::Collection(CommitColType::List, _, _) => Pred::List,
+            CommitStep::Collection(CommitColType::Set, _, _) => Pred::Set,
+            CommitStep::Collection(CommitColType::Map { .. }, _, _) => Pred::Map,
+            CommitStep::Hashed(_) => Pred::Hash,
+            CommitStep::Merklized(_) => Pred::Merklize,
+            CommitStep::Concealed(_) => Pred::Conceal,
+        }
+    }
+
+    fn attributes(&self) -> SmallVec<Attr> {
+        match self {
+            CommitStep::Collection(_, sizing, _) => small_vec![Attr::LenRange((*sizing).into())],
+            CommitStep::Concealed(from) => small_vec![Attr::Concealed(from.clone())],
+            CommitStep::Serialized(_) | CommitStep::Hashed(_) | CommitStep::Merklized(_) => none!(),
+        }
+    }
+
+    fn content(&self) -> TinyVec<Box<VesperCommit>> {
+        match self {
+            CommitStep::Collection(CommitColType::List, _, val) |
+            CommitStep::Collection(CommitColType::Set, _, val) => {
+                tiny_vec![Box::new(VesperCommit {
+                    subject: val.name.to_ident(),
+                    predicate: Pred::Element,
+                    attributes: none!(),
+                    content: none!(),
+                    comment: None
+                })]
+            }
+            CommitStep::Collection(CommitColType::Map { key }, _, val) => {
+                tiny_vec![
+                    Box::new(VesperCommit {
+                        subject: key.name.to_ident(),
+                        predicate: Pred::MapKey,
+                        attributes: none!(),
+                        content: none!(),
+                        comment: None
+                    }),
+                    Box::new(VesperCommit {
+                        subject: val.name.to_ident(),
+                        predicate: Pred::MapValue,
+                        attributes: none!(),
+                        content: none!(),
+                        comment: None
+                    })
+                ]
+            }
+            CommitStep::Serialized(_) |
+            CommitStep::Hashed(_) |
+            CommitStep::Merklized(_) |
+            CommitStep::Concealed(_) => empty!(),
+        }
+    }
+}
+
+impl CommitmentLayout {
+    pub fn to_vesper(&self) -> VesperCommit {
+        let subject = self.idty().name.to_ident();
+
+        // SecretSeal commitment tagged=""
+        //     BlindSeal rec serialized
+
+        let content = self.fields().iter().map(|field| {
+            Box::new(VesperCommit {
+                subject: field.subject(),
+                predicate: field.predicate(),
+                attributes: field.attributes(),
+                content: field.content(),
+                comment: None,
+            })
+        });
+
+        VesperCommit {
+            subject,
+            predicate: Pred::Commitment,
+            attributes: confined_vec![Attr::Tagged(self.tag())],
+            content: Confined::from_iter_unsafe(content),
+            comment: None,
+        }
+    }
+}

--- a/commit_verify/src/vesper.rs
+++ b/commit_verify/src/vesper.rs
@@ -25,7 +25,7 @@ use strict_types::layout::vesper::LenRange;
 use strict_types::typesys::TypeFqn;
 use vesper::{AttrVal, Attribute, Expression, Predicate, TExpr};
 
-use crate::{CommitColType, CommitStep, CommitmentLayout};
+use crate::{CommitColType, CommitLayout, CommitStep};
 
 pub type VesperCommit = TExpr<Pred>;
 
@@ -157,7 +157,7 @@ impl CommitStep {
     }
 }
 
-impl CommitmentLayout {
+impl CommitLayout {
     pub fn to_vesper(&self) -> VesperCommit {
         let subject = self.idty().name.to_ident();
 

--- a/commit_verify/src/vesper.rs
+++ b/commit_verify/src/vesper.rs
@@ -33,10 +33,10 @@ pub type VesperCommit = TExpr<Pred>;
 #[display(lowercase)]
 pub enum Pred {
     Commitment,
-    Serialize,
-    Hash,
-    Merklize,
-    Conceal,
+    Serialized,
+    Hashed,
+    Merklized,
+    Concealed,
     List,
     Set,
     Element,
@@ -56,6 +56,7 @@ pub enum Attr {
     Tagged(&'static str),
     Concealed(TypeFqn),
     LenRange(LenRange),
+    Hasher,
 }
 #[derive(Clone, Eq, PartialEq, Hash, Debug, Display)]
 #[display(inner)]
@@ -74,6 +75,7 @@ impl Attribute for Attr {
             Attr::Tagged(_) => Some(tn!("tagged")),
             Attr::Concealed(_) => Some(tn!("concealed")),
             Attr::LenRange(_) => Some(tn!("len")),
+            Attr::Hasher => Some(tn!("hasher")),
         }
     }
 
@@ -82,6 +84,7 @@ impl Attribute for Attr {
             Attr::Tagged(tag) => AttrVal::Expr(AttrExpr::Tag(tag)),
             Attr::Concealed(fqn) => AttrVal::Ident(fqn.name.to_ident()),
             Attr::LenRange(range) => AttrVal::Expr(AttrExpr::LenRange(range.clone())),
+            Attr::Hasher => AttrVal::Ident(tn!("SHA256")),
         }
     }
 }
@@ -101,13 +104,13 @@ impl CommitStep {
 
     fn predicate(&self) -> Pred {
         match self {
-            CommitStep::Serialized(_) => Pred::Serialize,
+            CommitStep::Serialized(_) => Pred::Serialized,
             CommitStep::Collection(CommitColType::List, _, _) => Pred::List,
             CommitStep::Collection(CommitColType::Set, _, _) => Pred::Set,
             CommitStep::Collection(CommitColType::Map { .. }, _, _) => Pred::Map,
-            CommitStep::Hashed(_) => Pred::Hash,
-            CommitStep::Merklized(_) => Pred::Merklize,
-            CommitStep::Concealed(_) => Pred::Conceal,
+            CommitStep::Hashed(_) => Pred::Hashed,
+            CommitStep::Merklized(_) => Pred::Merklized,
+            CommitStep::Concealed(_) => Pred::Concealed,
         }
     }
 
@@ -177,7 +180,7 @@ impl CommitLayout {
         VesperCommit {
             subject,
             predicate: Pred::Commitment,
-            attributes: confined_vec![Attr::Tagged(self.tag())],
+            attributes: confined_vec![Attr::Hasher, Attr::Tagged(self.tag())],
             content: Confined::from_iter_unsafe(content),
             comment: None,
         }


### PR DESCRIPTION
This allows self-description of commitment workflows (using Vesper format). It also adds additional checks for merklized and hashed data and support for unnamed collection types