### PR TITLE
Add support for ReservedBytes<26> type in type system

### DIFF
--- a/commit_verify/src/stl.rs
+++ b/commit_verify/src/stl.rs
@@ -33,6 +33,7 @@ fn _commit_verify_stl() -> Result<TypeLib, CompileError> {
     .transpile::<ReservedBytes<1>>()
     .transpile::<ReservedBytes<2>>()
     .transpile::<ReservedBytes<4>>()
+    .transpile::<ReservedBytes<26>>()
     .transpile::<mpc::MerkleConcealed>()
     .transpile::<mpc::MerkleTree>()
     .transpile::<mpc::MerkleBlock>()


### PR DESCRIPTION
## Description

This PR fixes the `UnknownType` errors during RGB21 asset issuance.

### Problem

After addressing the TypeAbsent errors, a new error appeared:
`UnknownType(SemId(Array<32>(de2717351edbb73c62b42378da72bf9414d2bb92374497f2997e1240d537832a)))`

During recursive type checking, the system failed to find the `ReservedBytes<26>` type used in the NFT's `_reserved` field.

### Root Cause

The type system in `commit_verify` was missing support for the `ReservedBytes<26>` type that's required by RGB21 NFT structures.

### Solution

Add `ReservedBytes<26>` to the type system to complete type resolution for RGB21 NFT structures.

### Related Issues

Part of the fix for [Addressing type resolution in RGB21 asset issuance process](https://github.com/pandora-prime/rgb-issuers/issues/2)

### Testing

Successfully tested with FAC asset issuance after applying this fix along with the other required changes.